### PR TITLE
follow up librime, avoid path-string conversion

### DIFF
--- a/src/modules.cc
+++ b/src/modules.cc
@@ -1,7 +1,7 @@
 #include <cstdio>
 #include <rime/common.h>
 #include <rime/registry.h>
-#include <rime_api.h>
+#include <rime/service.h>
 #include "lib/lua_templates.h"
 #include "lua_gears.h"
 
@@ -17,8 +17,11 @@ static bool file_exists(const char *fname) noexcept {
 }
 
 static void lua_init(lua_State *L) {
-  const auto user_dir = std::string(RimeGetUserDataDir());
-  const auto shared_dir = std::string(RimeGetSharedDataDir());
+  // path::string() returns native encoding on Windows
+  const auto user_dir =
+      rime::Service::instance().deployer().user_data_dir.string();
+  const auto shared_dir =
+      rime::Service::instance().deployer().shared_data_dir.string();
 
   types_init(L);
   lua_getglobal(L, "package");

--- a/src/types.cc
+++ b/src/types.cc
@@ -308,7 +308,8 @@ namespace ReverseDbReg {
   using T = ReverseDb;
 
   an<T> make(const string &file) {
-    an<T> db = New<ReverseDb>(string(RimeGetUserDataDir()) +  "/" + file);
+    an<T> db = New<ReverseDb>(
+        Service::instance().deployer().user_data_dir / file);
     db->Load();
     return db;
   }

--- a/src/types_ext.cc
+++ b/src/types_ext.cc
@@ -263,6 +263,10 @@ namespace UserDbReg{
     return {};
   }
 
+  string file_name(const T& t) {
+    return t.file_path().u8string();
+  }
+
   bool Open(T &t) { return t.Open(); }
   bool Close(T &t) { return t.Close(); }
   bool OpenReadOnly(T &t) { return t.OpenReadOnly(); }
@@ -300,7 +304,7 @@ namespace UserDbReg{
     {"read_only",WRAPMEM(T, readonly)},
     {"disabled",WRAPMEM(T, disabled)},
     {"name", WRAPMEM(T, name)},
-    {"file_name", WRAPMEM(T, file_name)},
+    {"file_name", WRAP(file_name)},
     { NULL, NULL },
   };
 


### PR DESCRIPTION
Avoid using `RimeGet*Dir()` from `rime_api`. They return native path on Windows and coding conversion is incurred.

When passing path from lua to librime class, use either rime::path object or UTF-8 encoded string.